### PR TITLE
create a new world when starting a game

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -496,7 +496,7 @@ bool ClientLauncher::launch_game(std::string &error_message,
 
 		if (!fs::PathExists(worldspec.path)) {
 			error_message = gettext("Provided world path doesn't exist: ")
-					+ worldspec.path;
+				+ worldspec.path;
 			errorstream << error_message << std::endl;
 			return false;
 		}

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -344,7 +344,7 @@ std::vector<WorldSpec> getAvailableWorlds()
 	return worlds;
 }
 
-void loadGameConfAndInitWorld(const std::string &path, const std::string &name,
+std::string loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 		const SubgameSpec &gamespec, bool create_world)
 {
 	std::string final_path = path;
@@ -422,6 +422,7 @@ void loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 	// The Settings object is no longer needed for created worlds
 	if (new_game_settings)
 		delete game_settings;
+	return final_path;
 }
 
 std::vector<std::string> getEnvModPaths()

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -97,5 +97,5 @@ std::vector<WorldSpec> getAvailableWorlds();
 
 // loads the subgame's config and creates world directory
 // and world.mt if they don't exist
-void loadGameConfAndInitWorld(const std::string &path, const std::string &name,
+std::string loadGameConfAndInitWorld(const std::string &path, const std::string &name,
 		const SubgameSpec &gamespec, bool create_world);


### PR DESCRIPTION
create a new world when starting a game

Now `minetest --gameid <foo> --go` should work.
Previously it would fail because a world was not specified, and the
default one did not exist.

Change-Id: Ic6001f73713d59930e96c3f2a30395f5b0b8cbb9