### PR TITLE
split conda package into two

### DIFF
--- a/python/examples/environment.yml
+++ b/python/examples/environment.yml
@@ -4,6 +4,6 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - minetest
+  - minetest-gymnasium
   - moviepy
   - jupyter

--- a/rattler-build-recipe/README.md
+++ b/rattler-build-recipe/README.md
@@ -1,10 +1,15 @@
 # rattler-build recipe
 
-A [rattler-build](https://prefix-dev.github.io/rattler-build/latest/) recipe.
+[rattler-build](https://prefix-dev.github.io/rattler-build/latest/) recipes.
 
 Usage:
 
 ```sh
-rattler-build build --package-format=conda --recipe=./rattler-build-recipe/recipe.yaml
+rattler-build build --package-format=conda --recipe-dir=./rattler-build-recipe -c conda-forge -c ./output
 ls -lh output/linux-64
 ```
+
+Then you need to upload the .conda files to
+https://prefix.dev/channels/obelisk-public and / or
+https://prefix.dev/channels/obelisk. We should be able to automate that, but for now
+just `scp` the files to your laptop and upload them using the web UI.

--- a/rattler-build-recipe/minetest-gymnasium/recipe.yaml
+++ b/rattler-build-recipe/minetest-gymnasium/recipe.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+# https://prefix-dev.github.io/rattler-build/latest/recipe_file/
+context: {}
+package:
+  name: minetest-gymnasium
+  version: ${{ env.get_default("GIT_DESCRIBE_TAG", env.get_default("GIT_FULL_HASH", "0.2")) }}
+
+source:
+  path: ../../
+
+build:
+  number: 0
+  script: python -m pip install ./python -v
+  noarch: python
+
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+  run:
+    - minetest
+    # python deps
+    - gymnasium
+    - numpy =1.26
+    - pycapnp >=1.1.1 # need 4b75fe3b5ea97a80a0d349a42c143c989fe85d5e
+
+about:
+  repository: https://github.com/Astera-org/minetest
+  summary: 'Minetest gymnasium interface'
+
+tests:
+  - python:
+      imports:
+        - minetest
+  - script:
+    # Install the devtest game, which is needed for python test.
+    - mkdir ${CONDA_PREFIX}/share/minetest/games
+    - ln -s -t ${CONDA_PREFIX}/share/minetest/games ${PWD}/games/devtest
+    - if [[ $(minetest --gameid list) != "devtest" ]]; then exit 1; fi
+    - cd python && pytest --timeout=60 -v .
+    files:
+      source:
+        - games/devtest/
+        - python/tests/
+        - python/pyproject.toml
+    requirements:
+      run:
+        - pillow
+        - pytest
+        - pytest-timeout

--- a/rattler-build-recipe/minetest/build.sh
+++ b/rattler-build-recipe/minetest/build.sh
@@ -21,5 +21,3 @@ cmake -B build \
 
 cmake --build build
 cmake --install build
-
-python -m pip install ./python -v

--- a/rattler-build-recipe/minetest/recipe.yaml
+++ b/rattler-build-recipe/minetest/recipe.yaml
@@ -6,10 +6,10 @@ package:
   version: ${{ env.get_default("GIT_DESCRIBE_TAG", env.get_default("GIT_FULL_HASH", "0.2")) }}
 
 source:
-  path: ../
+  path: ../../
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -45,21 +45,14 @@ requirements:
     - pkg-config
     - zlib
     - zstd
-    # python deps
-    - pip
-    - python <3.12
   run:
     # I think needed because their recipe doesn't specify run_exports.
     # Otherwise this should be inferred from presence in host.
     - luajit-openresty
-    # python deps
-    - gymnasium
-    - numpy =1.26
-    - pycapnp >=1.1.1 # need 4b75fe3b5ea97a80a0d349a42c143c989fe85d5e
 
 about:
   repository: https://github.com/Astera-org/minetest
-  summary: 'Minetest + gymnasium interface'
+  summary: 'Minetest with RPC interface'
 
 tests:
   # We should probably run minetest --run-unittests, but last time I tried
@@ -67,23 +60,11 @@ tests:
   - package_contents:
       bin:
         - minetest
-  - python:
-      imports:
-        - minetest
   - script:
     # Install the devtest game, which is needed for python test.
     - mkdir ${CONDA_PREFIX}/share/minetest/games
     - ln -s -t ${CONDA_PREFIX}/share/minetest/games ${PWD}/games/devtest
     - if [[ $(minetest --gameid list) != "devtest" ]]; then exit 1; fi
-    - cd python && pytest --timeout=60 -v .
     files:
       source:
         - games/devtest/
-        - python/tests/
-        - python/pyproject.toml
-    requirements:
-      run:
-        - pillow
-        - pytest
-        - pytest-timeout
-


### PR DESCRIPTION
having a separate package for the python lets us mark the python dependency as `noarch` meaning it will work with any version of python.

Should also be faster to build only one paackage if we only make changes to the Python or the C++ but not both.