### PR TITLE
fix github checks

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -132,6 +132,7 @@ jobs:
           CC: clang-14
           CXX: clang++-14
           CMAKE_BUILD_SERVER: FALSE
+          CMAKE_FLAGS: -DUSE_SDL2=ON
 
       - name: Run pytest
         # Needed so conda environment is active

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-12 # TODO: switch to macos-latest once pycapnp on conda-forge supports arm64
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
- headless python test now requires SDL2 rendering
- MacOS only supports AMD64 CPUs, so specify a runner with those