### PR TITLE
Upgrade to pycapnp 2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,16 +15,13 @@ dependencies:
   - gettext
   - gmp
   - jsoncpp
-  - libcurl
+  - libcurl >=8.2.1,<9
   - libjpeg-turbo
   - libpng
   - libsqlite
   - luajit-openresty
+  - mold
   - ncurses
-  # TODO: move mold from
-  # Dockerfile / apt-get to here once
-  # https://github.com/conda-forge/capnproto-feedstock/pull/32
-  # (currently mold requires OpenSSL 3 and capnproto requires 1)
   - ninja
   - pkg-config
   - sdl2
@@ -37,10 +34,10 @@ dependencies:
   - pip
   - pip:
     - -e python
-  - pycapnp>=1.1.1,<2
+  - pycapnp >=2,<3
   - pygame
   - pytest # test only
   - pytest-repeat # test only
-  - python=3.11
+  - python =3.11
   # others
   - pre-commit

--- a/rattler-build-recipe/minetest-gymnasium/recipe.yaml
+++ b/rattler-build-recipe/minetest-gymnasium/recipe.yaml
@@ -3,7 +3,7 @@
 context: {}
 package:
   name: minetest-gymnasium
-  version: ${{ env.get_default("GIT_DESCRIBE_TAG", env.get_default("GIT_FULL_HASH", "0.7")) }}
+  version: "0.8"
 
 source:
   path: ../../
@@ -20,11 +20,11 @@ requirements:
     - python
     - setuptools
   run:
-    - minetest =0.6
+    - minetest =0.7
     # python deps
     - gymnasium
     - numpy =1.26
-    - pycapnp >=1.1.1,<2 # need 4b75fe3b5ea97a80a0d349a42c143c989fe85d5e
+    - pycapnp >=2,<3
 
 about:
   repository: https://github.com/Astera-org/minetest

--- a/rattler-build-recipe/minetest/recipe.yaml
+++ b/rattler-build-recipe/minetest/recipe.yaml
@@ -3,7 +3,7 @@
 context: {}
 package:
   name: minetest
-  version: ${{ env.get_default("GIT_DESCRIBE_TAG", env.get_default("GIT_FULL_HASH", "0.6")) }}
+  version: "0.7"
 
 source:
   path: ../../
@@ -26,7 +26,7 @@ requirements:
         - ${{ cdt("mesa-libgl-devel") }}
   host:
     # minetest deps
-    - capnproto =0.10.2 # pycapnp currently requires this. https://github.com/conda-forge/pycapnp-feedstock/pull/33
+    - capnproto >=1.0.2,<2
     - freetype
     - gmp
     - jsoncpp


### PR DESCRIPTION
They unfortunately removed their synchronous API so I had to use asyncio
and it's a bit involved to do it in a way that preserves the gymnasium
API.

The main benefit is this lets us upgrade libcurl to a newer version
that doesn't conflict with packages used in sheeprl.
