### PR TITLE
use fixed_map_seed instead of current time

### DIFF
--- a/rattler-build-recipe/minetest-gymnasium/recipe.yaml
+++ b/rattler-build-recipe/minetest-gymnasium/recipe.yaml
@@ -9,7 +9,7 @@ source:
   path: ../../
 
 build:
-  number: 2
+  number: 3
   script: python -m pip install ./python -v
   noarch: python
 
@@ -20,7 +20,7 @@ requirements:
     - python
     - setuptools
   run:
-    - minetest =0.8
+    - minetest =0.9
     # python deps
     - gymnasium
     - numpy =1.26

--- a/rattler-build-recipe/minetest/recipe.yaml
+++ b/rattler-build-recipe/minetest/recipe.yaml
@@ -3,7 +3,7 @@
 context: {}
 package:
   name: minetest
-  version: "0.8"
+  version: "0.9"
 
 source:
   path: ../../


### PR DESCRIPTION
this should result in the server port chosen being independent of the time,
which will hopefully fix port colissions we were seeing.

