### PR TITLE
fix reset while env is open

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,18 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "type": "debugpy",
+            "request": "launch",
+            "name": "minetest_test.py",
+            "module": "pytest",
+            "justMyCode": false,
+            "args": [
+                "-sv",
+                "-o log_cli=true",
+                "${workspaceFolder}/python/tests/minetest_test.py",
+            ]
+        },
+        {
             "type": "lldb",
             "request": "launch",
             "name": "Debug for handshaker.py",

--- a/python/tests/minetest_test.py
+++ b/python/tests/minetest_test.py
@@ -71,6 +71,33 @@ def contains_key(config_path: os.PathLike, key: str):
     return False
 
 
+def test_double_reset(world_dir, minetest_executable, server_addr, caplog):
+    caplog.set_level(logging.DEBUG)
+    artifact_dir = tempfile.mkdtemp()
+    display_size = (223, 111)
+    env = gym.make(
+        "minetest-v0",
+        executable=minetest_executable,
+        artifact_dir=artifact_dir,
+        server_addr=server_addr,
+        render_mode="rgb_array",
+        display_size=display_size,
+        world_dir=world_dir,
+        headless=True,
+        verbose_logging=True,
+        additional_observation_spaces={
+            "return": gym.spaces.Box(low=-(2**20), high=2**20, shape=(1,))
+        },
+    )
+
+    # Context manager to make sure close() is called even if test fails.
+    with env:
+        initial_obs, info = env.reset()
+        initial_obs, info = env.reset()
+
+    shutil.rmtree(artifact_dir)  # Only on success so we can inspect artifacts.
+
+
 def test_minetest_basic(world_dir, minetest_executable, server_addr, caplog):
     caplog.set_level(logging.DEBUG)
     artifact_dir = tempfile.mkdtemp()
@@ -109,7 +136,8 @@ def test_minetest_basic(world_dir, minetest_executable, server_addr, caplog):
                 action["mouse"] = np.array([0.0, 1.0])
 
             obs, reward, terminated, truncated, info = env.step(action)
-            assert not terminated and not truncated
+            assert not terminated
+            assert not truncated
             assert "return" in obs
             assert "image" in obs
             # TODO: I've seen the system get into a mode where the output is always 480, 640, 3
@@ -129,6 +157,7 @@ def test_minetest_basic(world_dir, minetest_executable, server_addr, caplog):
             # on Mac or when rendering with nvidia.
             if sys.platform == "darwin" or shutil.which("nvidia-smi"):
                 assert img_data.sum() > 0, "All black image"
+
     assert nonzero_reward, f"see images in {artifact_dir}"
 
     shutil.rmtree(artifact_dir)  # Only on success so we can inspect artifacts.
@@ -172,9 +201,11 @@ def test_async_vector_env(world_dir, minetest_executable, server_addr, caplog):
     caplog.set_level(logging.DEBUG)
     artifact_dir = tempfile.mkdtemp()
     num_envs = 2
+    max_episode_steps = 3
     envs = [
         lambda: gym.make(
             "minetest-v0",
+            max_episode_steps=max_episode_steps,
             executable=minetest_executable,
             artifact_dir=artifact_dir,
             server_addr=server_addr,
@@ -208,7 +239,9 @@ def test_async_vector_env(world_dir, minetest_executable, server_addr, caplog):
             assert len(terminated) == num_envs
             assert len(truncated) == num_envs
             assert not terminated.any()
-            assert not truncated.any()
+            if i == max_episode_steps - 1:
+                assert truncated.all()
+            else:
+                assert not truncated.any()
 
         shutil.rmtree(artifact_dir)  # Only on success so we can inspect artifacts.
-


### PR DESCRIPTION
* fix reset while env is open
* fix bad error message when KjException is raised in a multiprocessing subprocess
* add tests for AsyncVectorEnv and double reset