### PR TITLE
respect config.game_dir in findSubgame().

### DIFF
--- a/python/minetest/minetest_env.py
+++ b/python/minetest/minetest_env.py
@@ -360,7 +360,6 @@ class MinetestEnv(gym.Env):
             screen_w=self.display_size.width,
             screen_h=self.display_size.height,
             fov=self.fov_y,
-            game_dir=self.game_dir,
             # Adapt HUD size to display size, based on (1024, 600) default
             hud_scaling=self.display_size[0] / 1024,
             # Attempt to improve performance. Impact unclear.
@@ -380,6 +379,8 @@ class MinetestEnv(gym.Env):
             emergequeue_limit_diskonly=1000000,
             emergequeue_limit_generate=1000000,
         )
+        if self.game_dir:
+            config["game_dir"] = self.game_dir
         # Some games we carea bout currently use insecure lua features.
         config["secure.enable_security"] = False
 

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -75,26 +75,32 @@ SubgameSpec findSubgame(const std::string &id)
 	if (id.empty())
 		return SubgameSpec();
 
-	// Get games install locations
-	Strfnd search_paths(getSubgamePathEnv());
 
-	// Get all possible paths fo game
+	// Get all possible paths for game
 	std::vector<std::string> find_paths;
-	while (!search_paths.at_end()) {
-		std::string path = search_paths.next(PATH_DELIM);
-		path.append(DIR_DELIM).append(id);
-		find_paths.emplace_back(path);
-		path.append("_game");
-		find_paths.emplace_back(path);
-	}
+	static constexpr const char* game_dir_setting_key = "game_dir";
 
-	std::string game_base = DIR_DELIM;
-	game_base = game_base.append("games").append(DIR_DELIM).append(id);
-	std::string game_suffixed = game_base + "_game";
-	find_paths.emplace_back(porting::path_user + game_suffixed);
-	find_paths.emplace_back(porting::path_user + game_base);
-	find_paths.emplace_back(porting::path_share + game_suffixed);
-	find_paths.emplace_back(porting::path_share + game_base);
+	if (g_settings->exists(game_dir_setting_key)) {
+		find_paths.emplace_back(g_settings->get(game_dir_setting_key));
+	} else {
+		// Get games install locations
+		Strfnd search_paths(getSubgamePathEnv());
+		while (!search_paths.at_end()) {
+			std::string path = search_paths.next(PATH_DELIM);
+			path.append(DIR_DELIM).append(id);
+			find_paths.emplace_back(path);
+			path.append("_game");
+			find_paths.emplace_back(path);
+		}
+
+		std::string game_base = DIR_DELIM;
+		game_base = game_base.append("games").append(DIR_DELIM).append(id);
+		std::string game_suffixed = game_base + "_game";
+		find_paths.emplace_back(porting::path_user + game_suffixed);
+		find_paths.emplace_back(porting::path_user + game_base);
+		find_paths.emplace_back(porting::path_share + game_suffixed);
+		find_paths.emplace_back(porting::path_share + game_base);
+	}
 
 	// Find game directory
 	std::string game_path;


### PR DESCRIPTION
Before, specifying a game dir would fail if that game dir was not a sub-dir of one of the default search paths.
