### PR TITLE
Exposes some player attributes, player metadata, and hud strings

### DIFF
--- a/minetest-gymnasium/minetest/proto/remoteclient.capnp
+++ b/minetest-gymnasium/minetest/proto/remoteclient.capnp
@@ -106,16 +106,7 @@ struct Image {
   data @2 :Data;
 }
 
-# Generic map type doesn't work for Float32, see https://capnproto.org/language.html#generic-types. So keeping it simple.
-struct MapTextFloat32 {
-  entries @0 :List(Entry);
-
-  struct Entry {
-    key @0 :Text;
-    value @1 :Float32;
-  }
-}
-
+# Generic map would not compile. If it did, it would only work for pointer types, see: https://capnproto.org/language.html#generic-types.
 struct MapTextText {
   entries @0 :List(Entry);
 
@@ -127,11 +118,13 @@ struct MapTextText {
 
 struct Observation {
   image @0 :Image;
-  # TODO: make this optional so that the agent can tell if the game is done loading.
-  reward @1 :Float32;
-  done @2 :Bool;
-  aux @3 :MapTextFloat32;
-  playerMeta @4 :MapTextText;
+  hudElements @1 :MapTextText;
+  playerHealth @2 :UInt16;
+  playerHealthMax @3 :UInt16;
+  playerBreath @4 :UInt16;
+  playerBreathMax @5 :UInt16;
+  playerIsDead @6 :Bool;
+  playerMetadata @7 :MapTextText;
 }
 
 interface Minetest {

--- a/src/player.h
+++ b/src/player.h
@@ -242,6 +242,17 @@ public:
 	// Get actual usable number of hotbar items (clamped to size of "main" list)
 	u16 getMaxHotbarItemcount();
 
+	// NOTE(obelisk): We need this because getHud and friends release the lock too early.
+	[[nodiscard]] constexpr auto exposeTheHud() const & noexcept -> auto& {
+		return hud;
+	}
+	auto exposeTheHud() const && = delete;
+
+	// NOTE(obelisk): We need this because getHud and friends release the lock too early.
+	[[nodiscard]] constexpr auto exposeTheMutex() & -> auto& {
+		return m_mutex;
+	}
+
 protected:
 	std::string m_name;
 	v3f m_speed; // velocity; in BS-space


### PR DESCRIPTION
Exposes some player attributes, player metadata, and hud strings (without processing) directly to python. 

The gym environment uses that data to fill the `info` object:

```json
{
  "hud_elements": [
    { "name": "", "text": "" },
    { "name": "", "text": "" },
    { "name": "score", "text": "Score: 0" },
    { "name": "health", "text": "Health: 20" },
    { "name": "food", "text": "Food: 600" },
    { "name": "water", "text": "Water: 600" }
  ],
  "player_health": 20,
  "player_health_max": 20,
  "player_breath": 10,
  "player_breath_max": 10,
  "player_is_dead": false,
  "player_metadata": {
    "hud_ids": "return {health=3,food=4,score=2,water=5}",
    "water": "600",
    "food": "600",
    "score": "0"
  }
}
```

Consumers of the environment can define additional observation spaces derived from this info like so:

```py
additional_observation_spaces = {
    "health": minetest.minetest_env.AdditionalObservationSpace(
        space = gymnasium.spaces.Box(0, 20, (1,), dtype=np.int32),
        value_fn = lambda info: np.array(info["player_health"], dtype=np.int32)
    ),
    "food": minetest.minetest_env.AdditionalObservationSpace(
        space = gymnasium.spaces.Box(0, 1000, (1,), dtype=np.float32),
        value_fn = lambda info: np.array([float(info["player_metadata"]["food"])], dtype=np.float32)
    ),
    "water": minetest.minetest_env.AdditionalObservationSpace(
        space = gymnasium.spaces.Box(0, 1000, (1,), dtype=np.float32),
        value_fn = lambda info: np.array([float(info["player_metadata"]["water"])], dtype=np.float32)
    ),
}
```